### PR TITLE
#1. Ubuntu/Debian Quick Start Guide issue: ClickHouse does not start …

### DIFF
--- a/index.html
+++ b/index.html
@@ -589,7 +589,7 @@ sudo apt-get update
 sudo apt-get install -y clickhouse-server clickhouse-client
 
 sudo service clickhouse-server start
-clickhouse-client</pre>
+clickhouse-client --password</pre>
                     </div>
                     <div class="tab-pane syntax" id="rpm" role="tabpanel" aria-labelledby="rpm-tab">
                         <pre>sudo yum install yum-utils


### PR DESCRIPTION
…with no password.

This is a suggested fix for #1 